### PR TITLE
Fix copy text for natrium

### DIFF
--- a/src/pages/CalculatorPage.jsx
+++ b/src/pages/CalculatorPage.jsx
@@ -389,7 +389,7 @@ export default function CalculatorPage(props) {
     var outputText = `Vocht: ${voedingswaardeLijst.totaal.hoeveelheid} ml/kg/d; 
 Calorisch: ${voedingswaardeLijst.totaal.calorieën} kcal/kg/d; 
 Glucose Intake: ${voedingswaardeLijst.totaal.koolhydraten} mg/kg/min; 
-Natrium Intake: ${voedingswaardeLijst.totaal.koolhydraten} mmol/kg/d`;
+Natrium Intake: ${voedingswaardeLijst.totaal.natrium} mmol/kg/d`;
     navigator.clipboard.writeText(outputText).then(() => {
       alert("De volgende informatie is gekopieërd:\n" + outputText);
     });


### PR DESCRIPTION
## Summary
- fix incorrect field when copying natrium intake to the clipboard

## Testing
- `npm run build` *(fails: vite not found)*